### PR TITLE
fix: 프론트엔드 컨테이너 Nginx 단순화, 배포 롤백 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -166,7 +166,14 @@ jobs:
                 --restart unless-stopped \
                 -p 127.0.0.1:3000:80 \
                 dpbr-frontend:previous
-              echo "⚠️ Rollback completed - running previous version"
+
+              # 롤백 컨테이너 헬스체크
+              sleep 5
+              if curl -sf --connect-timeout 5 "http://127.0.0.1:3000/" > /dev/null; then
+                echo "⚠️ Rollback completed - previous version is running"
+              else
+                echo "❌ Rollback container also unhealthy!"
+              fi
             else
               echo "⚠️ No previous image available for rollback"
             fi

--- a/dpbr_front/nginx/nginx.conf
+++ b/dpbr_front/nginx/nginx.conf
@@ -12,10 +12,12 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    # 정적 에셋 캐싱
+    # 정적 에셋 캐싱 (location 내 add_header 시 상위 보안 헤더 미상속 → 명시 추가)
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
     }
 
     # Gzip 압축


### PR DESCRIPTION
## Summary
- `dpbr_front/nginx/nginx.conf`: 깨진 `host.docker.internal` 백엔드 프록시 제거, 정적 파일 서빙 전용으로 단순화 (API 라우팅은 호스트 레벨 Nginx가 처리)
- `deploy.yml`: 배포 실패 시 이전 이미지로 자동 롤백 추가, Nginx 경유 health check 추가

## 수정된 문제
| 문제 | 원인 | 수정 |
|------|------|------|
| 프론트엔드 API 프록시 실패 | `host.docker.internal`은 Linux(OCI)에서 미지원 | 호스트 Nginx가 API 라우팅 → 컨테이너 Nginx는 정적 파일만 |
| 배포 실패 시 롤백 없음 | 실패해도 이전 버전 복구 불가 | `dpbr-frontend:previous` 태그 보존 후 롤백 |

## 아키텍처 (백엔드 PR과 함께 적용)
```
브라우저 → 호스트 Nginx (:80)
    ├─ /api/*  → 127.0.0.1:8000 (백엔드 Docker)
    ├─ /health → 127.0.0.1:8000 (백엔드 Docker)
    └─ /*      → 127.0.0.1:3000 (프론트 Docker → 정적 파일)
```